### PR TITLE
Migrate to Anna's Archive 🚂

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Zlibrary
+# Anna's Archive API (previously Zlibrary)
+
+###### After the seizure notice by the USPS, ZLibrary can only be accessed via TOR. Anna's Archive can be considered as a backup to ZLibrary, Library Genesis and other shadow libraries, so converting this API to be a wrapper of Anna's Archive.
 
 TODO: Describe the library.
 
@@ -16,7 +18,7 @@ TODO: Add steps for development of the application. (Do this after adding tests)
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/shettytejas/zlibrary. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/shettytejas/zlibrary/blob/master/CODE_OF_CONDUCT.md).
+Bug reports and pull requests are welcome on GitHub at https://github.com/shettytejas/annas_archive. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/shettytejas/annas_archive/blob/master/CODE_OF_CONDUCT.md).
 
 ## License
 
@@ -24,4 +26,4 @@ The library is available as open source under the terms of the [MIT License](htt
 
 ## Code of Conduct
 
-Everyone interacting in the Zlibrary project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/shettytejas/zlibrary/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the Anna's Archive project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/shettytejas/annas_archive/blob/master/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
After the seizure notice by the USPS, ZLibrary can only be accessed via TOR. Anna's Archive can be considered as a backup to ZLibrary, Library Genesis and other shadow libraries, so converting this API to be a wrapper of Anna's Archive.
